### PR TITLE
Changes timeouts for upstream to be more stable

### DIFF
--- a/jobs/nginx/templates/upstream.conf.erb
+++ b/jobs/nginx/templates/upstream.conf.erb
@@ -1,5 +1,5 @@
 upstream cf-routers {
   <% p('a9s_ssl_gateway.cf_routers').each do |router| %>
-  <%= "server #{router};" %>
+  <%= "server #{router} max_fails=1 fail_timeout=60s;" %>
   <% end %>
 }


### PR DESCRIPTION
That a first request to a upstream server wents wrong is ok, but any further requests should not be sent there until the service is available again. Therefore we set a timeout of 60 seconds, this is double the time a gorouter needs to be upgraded and reloaded, so after this 60 seconds it should be available again.