### PR TITLE
Make more nginx variables configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The SSL-Gateway bosh release provides SSL - termination for CloudFoundry apps an
 - bosh CLI v2
 
 ## Running the tests
-Create CloudFoundry user or use CF - admin user credentials 
+Create CloudFoundry user or use CF - admin user credentials
 ```
 cf create-user max@mustermann.com test123
 export CF_USER=max@mustermann.com
@@ -230,6 +230,9 @@ properties:
 | a9s_ssl_gateway.vserver[n].private_key | (TLS) private_key for TLS |
 | a9s_ssl_gateway.vserver[n].deny_all | [true / false] if set to true, all incoming requests are denied (can be combined with allow to implement whitelist) |
 | a9s_ssl_gateway.vserver[n].allow | [ IP / IP - range] Explicitly allows incoming requests from IP / IP - range (use this for whitelisting) |
+| a9s_ssl_gateway.client_max_body_size | [ default: 1536M ] max body size for file uploads (supports human readable scales K,M and G) |
+| a9s_ssl_gateway.proxy_read_timeout | [ default: 900 ] timeout in seconds for read requests  |
+| a9s_ssl_gateway.proxy_send_timeout | [ default: 900 ] timeout in seconds for file upload requests (supports human readable scales K,M and G) |
 
 *a9s_ssl_gateway.vserver[n].foo* - stands for property *foo* of an array element *n* in *a9s_ssl_gateway.vserver*
 
@@ -257,7 +260,7 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 ## Limitations
 
 ## Known Issues
-- __NOTE__: The pid file location for the ngninx process is hardcoded in the packaging script for nginx. We had to 
+- __NOTE__: The pid file location for the ngninx process is hardcoded in the packaging script for nginx. We had to
 do this dirty workaround to migrate a pid location change on an already deployed ssl-gateway.
 
 ## TODO
@@ -272,5 +275,3 @@ do this dirty workaround to migrate a pid location change on an already deployed
 - Add ratelimit spec property to SSL-Gateway to protect against ddos
 - The vhost worker production log is not created under /var/vcap/sys/log/virtual_host..
 - The vhost worker and api DaemonKit logs are surpressed
-
-

--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -47,3 +47,12 @@ properties:
     default: false
   a9s_ssl_gateway.ssh_routers:
     description: 'ssh upstream servers (access vms)'
+  a9s_ssl_gateway.client_max_body_size:
+    description: 'max body size for file uploads'
+    default: 1536M
+  a9s_ssl_gateway.proxy_read_timeout:
+    description: 'timeout in seconds for read requests'
+    default: 900
+  a9s_ssl_gateway.proxy_send_timeout:
+    description: 'timeout in seconds for file upload requests'
+    default: 900

--- a/jobs/nginx/templates/nginx.conf.erb
+++ b/jobs/nginx/templates/nginx.conf.erb
@@ -4,7 +4,7 @@
 #
 # This is optional and can be seen as a additional security feature.
 # If you have a sound network configuration that guarantees that only
-# request from the loadbalancers network can reach the ssl-gateway, 
+# request from the loadbalancers network can reach the ssl-gateway,
 # you can leave it off.
 user  vcap;
 worker_processes  12;
@@ -34,16 +34,16 @@ http {
   <% end %>
 
   access_log  /var/vcap/sys/log/nginx/access.log  main;
-  
+
   <% if p('a9s_ssl_gateway.enable_proxy_protocol') %>
-    <% p('a9s_ssl_gateway.load_balancer_address').each do |load_balancer| %> 
+    <% p('a9s_ssl_gateway.load_balancer_address').each do |load_balancer| %>
   set_real_ip_from <%= load_balancer %>;
     <% end %>
   real_ip_header proxy_protocol;
   real_ip_recursive on;
   <% end %>
 
-  client_max_body_size 512M;
+  client_max_body_size <%= p('a9s_ssl_gateway.client_max_body_size') %>;
 
   sendfile        on;
   tcp_nopush      on;
@@ -54,8 +54,8 @@ http {
   include /var/vcap/store/nginx/conf.d/*.conf;
   include /var/vcap/store/nginx/sites-enabled/*;
 
-  proxy_read_timeout 300;
-  proxy_send_timeout 300;
+  proxy_read_timeout <%= p('a9s_ssl_gateway.proxy_read_timeout') %>;
+  proxy_send_timeout <%= p('a9s_ssl_gateway.proxy_send_timeout') %>;
   proxy_headers_hash_bucket_size 128;
 
   server_tokens off;


### PR DESCRIPTION
This PR adds 3 more configuration options

* a9s_ssl_gateway.client_max_body_size: max upload size, should be larger than CC client_max_body_size (CC default is 1GB) -> I set the default to 1.5G because this is also set in the CC nginx config
* a9s_ssl_gateway.proxy_read_timeout: timeout for read requests in seconds, the default is 900 like in the CC nginx
a9s_ssl_gateway.proxy_send_timeout: timeout for upload / send requests in seconds, the default is 900 like in the CC nginx