### PR TITLE
Update Virtual host service worker and boshrelease 1.4.7

### DIFF
--- a/.final_builds/packages/virtual_host_service_worker/index.yml
+++ b/.final_builds/packages/virtual_host_service_worker/index.yml
@@ -19,6 +19,10 @@ builds:
     version: 7e170e1f3649ff035f61889f3f06f17f8f14bfe7
     blobstore_id: cd27913d-8809-4c2d-a210-e181ac2d2fee
     sha1: 280922a944e29c545d8893756bb57e1dd7df233b
+  84e76efe8d69c55680dba9f854de26c0b9b97d390d06ca98ab1f0832dd8eda97:
+    version: 84e76efe8d69c55680dba9f854de26c0b9b97d390d06ca98ab1f0832dd8eda97
+    blobstore_id: 28b38bca-72f9-404f-5526-678ac5341bb9
+    sha1: sha256:920516d66054dac53f59ed3fe35500de305538a030ae1cfa1acfcfd5abccbd88
   97cb81bd5eda13df1c6634a5f456268991ce3ece:
     version: 97cb81bd5eda13df1c6634a5f456268991ce3ece
     blobstore_id: 839629c3-2d28-463a-4ef7-9329b2ce75c1

--- a/releases/ssl-gateway/index.yml
+++ b/releases/ssl-gateway/index.yml
@@ -27,6 +27,8 @@ builds:
     version: "5"
   d38cdbbf-4b5d-4ee6-4881-30787fb2afc3:
     version: 1.0.0
+  de8b490b-2c24-41bd-70be-621b47062fa2:
+    version: 1.4.7
   e4776c7e-baf7-4f5d-7709-49f985c3185e:
     version: 1.2.5
   ee88a057-6c45-4655-a4a3-29c611fe070c:

--- a/releases/ssl-gateway/ssl-gateway-1.4.7.yml
+++ b/releases/ssl-gateway/ssl-gateway-1.4.7.yml
@@ -1,0 +1,62 @@
+name: ssl-gateway
+version: 1.4.7
+commit_hash: 8f271f6
+uncommitted_changes: false
+jobs:
+- name: virtual_host_service_api
+  version: b6fc93268fb119866fd86e48d17e695bf11f25bbf7bf02e2b06d81b90a42a839
+  fingerprint: b6fc93268fb119866fd86e48d17e695bf11f25bbf7bf02e2b06d81b90a42a839
+  sha1: sha256:b593c8c8d341c7e189fb1a3d36b4d1c038268638553d33d61a5ddffe857345cd
+  packages:
+  - ruby
+  - libpq
+  - libyaml
+  - zlib
+  - virtual_host_service_api
+- name: virtual_host_service_worker
+  version: 9d1943d89f9880bcb3e5abe8f82a61bf731814132a91e9bf495e8c84cc064ec8
+  fingerprint: 9d1943d89f9880bcb3e5abe8f82a61bf731814132a91e9bf495e8c84cc064ec8
+  sha1: sha256:d7442c8ec0d1934e6d27a2cc45e143f37cb9a107f206d0088aadaecec0225acb
+  packages:
+  - ruby
+  - virtual_host_service_worker
+packages:
+- name: libpq
+  version: aaaf251cf230807d9b2ede78cc669de668ffac150f899ab838fadb84a8083659
+  fingerprint: aaaf251cf230807d9b2ede78cc669de668ffac150f899ab838fadb84a8083659
+  sha1: sha256:ccc2f6f4d49bd30952698aea33dcb3a37690dbcc919d85923dc7d6eb4d02d729
+  dependencies: []
+- name: libyaml
+  version: ac3ab06e19435c2fec68b4a1009f423bd388a457416504f2f355e1a1e219f9cc
+  fingerprint: ac3ab06e19435c2fec68b4a1009f423bd388a457416504f2f355e1a1e219f9cc
+  sha1: sha256:4770002fb4b314ef013078069259645ce4362dac18fe3c9972f49d92ceab0002
+  dependencies: []
+- name: ruby
+  version: 943f4180b2277c3d43e3b23586a2677c7b10d3144c8236a92a43913a48492190
+  fingerprint: 943f4180b2277c3d43e3b23586a2677c7b10d3144c8236a92a43913a48492190
+  sha1: sha256:18c3f96f1b88c8f6598dac11222621fcdde2ef112759e5d15d0e2df2ebb1c84f
+  dependencies:
+  - libyaml
+  - zlib
+- name: virtual_host_service_api
+  version: b54519c6595c45fac15c1ccc1cf6c241adb368a1758da7eba6810932ba972a42
+  fingerprint: b54519c6595c45fac15c1ccc1cf6c241adb368a1758da7eba6810932ba972a42
+  sha1: sha256:85c2e1fe63f8fce4353fc5f8d76f363a507a4b56595d36769c9bed98c45bcc3b
+  dependencies:
+  - ruby
+  - libpq
+- name: virtual_host_service_worker
+  version: 84e76efe8d69c55680dba9f854de26c0b9b97d390d06ca98ab1f0832dd8eda97
+  fingerprint: 84e76efe8d69c55680dba9f854de26c0b9b97d390d06ca98ab1f0832dd8eda97
+  sha1: sha256:920516d66054dac53f59ed3fe35500de305538a030ae1cfa1acfcfd5abccbd88
+  dependencies:
+  - ruby
+- name: zlib
+  version: 0d561bd6e38f7aeaaff26b6b2134ec46d978f86f5da07ae2315e8beb62eb4a4c
+  fingerprint: 0d561bd6e38f7aeaaff26b6b2134ec46d978f86f5da07ae2315e8beb62eb4a4c
+  sha1: sha256:b4d0cb1e94a8bd6aef542608f2c2ca546b6fa3f85906fb6a13079374bff57e28
+  dependencies: []
+license:
+  version: 18a5ebae94d9c56046311fcc8eee7af11febd910396bb02e29bf09a986a027fe
+  fingerprint: 18a5ebae94d9c56046311fcc8eee7af11febd910396bb02e29bf09a986a027fe
+  sha1: sha256:f4ed094196a849abae33d47ae105e37c40f44ede46a926fa80f540ac0580546f

--- a/versions.yml
+++ b/versions.yml
@@ -8,3 +8,8 @@ name: ssl-gateway-v1.4.6
   url: https://s3-eu-west-1.amazonaws.com/anynines-bosh-releases/ssl-gateway-v1.4.6.tgz
   sha: a1d0c0a5fafe8ae1786b327888d2d628a79fbe4f92b5f660feb3451c53ab35c3
   version: 1.4.6
+
+name: ssl-gateway-v1.4.7
+  url: https://s3-eu-west-1.amazonaws.com/anynines-bosh-releases/ssl-gateway-v1.4.7.tgz
+  sha: a3f408803e08cb6902be1c8cf088de0418676dd7195dd76a1708538a0ecde527
+  version: 1.4.7


### PR DESCRIPTION
Resolves virtual_host_service_worker being unable to delete certificates with a subject containing a *. 